### PR TITLE
Add neovim and neovim-qt

### DIFF
--- a/bucket/neovim-qt.json
+++ b/bucket/neovim-qt.json
@@ -1,0 +1,32 @@
+{
+  "version": "0.2.16.1",
+  "description": "Neovim client library and GUI, in Qt5",
+  "homepage": "https://github.com/equalsraf/neovim-qt",
+  "license": "ISC",
+  "suggest": {
+    "neovim": "neovim"
+  },
+  "architecture": {
+    "64bit": {
+      "url": "https://github.com/equalsraf/neovim-qt/releases/download/v0.2.16.1/neovim-qt.zip",
+      "hash": "ddb4492db03da407703fb0ab271c4eb060250d1a7d71200e2b3b981cb0de59de"
+    }
+  },
+  "bin": "bin\\nvim-qt.exe",
+  "shortcuts": [
+    [
+      "bin\\nvim-qt.exe",
+      "Neovim QT"
+    ]
+  ],
+  "checkver": {
+    "github": "https://github.com/equalsraf/neovim-qt"
+  },
+  "autoupdate": {
+    "architecture": {
+      "64bit": {
+        "url": "https://github.com/equalsraf/neovim-qt/releases/download/v$version/neovim-qt.zip"
+      }
+    }
+  }
+}

--- a/bucket/neovim-qt.json
+++ b/bucket/neovim-qt.json
@@ -16,7 +16,7 @@
   "shortcuts": [
     [
       "bin\\nvim-qt.exe",
-      "Neovim QT"
+      "Neovim Qt"
     ]
   ],
   "checkver": {

--- a/bucket/neovim.json
+++ b/bucket/neovim.json
@@ -1,22 +1,19 @@
 {
-    "version": "0.4.4",
+    "version": "0.5.0",
     "description": "Vim-fork focused on extensibility and usability",
     "homepage": "https://neovim.io/",
     "license": {
         "identifier": "Apache-2.0,Vim",
         "url": "https://github.com/neovim/neovim/blob/master/LICENSE"
     },
-    "suggest": {
-        "vcredist": "extras/vcredist2015"
-    },
     "architecture": {
         "64bit": {
-            "url": "https://github.com/neovim/neovim/releases/download/v0.4.4/nvim-win64.zip",
-            "hash": "4b88daae8427624f82abb10eb6e527f4b0c600e83aaa9a0857d06106b445bbd3"
+            "url": "https://github.com/neovim/neovim/releases/download/v0.5.0/nvim-win64.zip",
+            "hash": "0064bd9f6b270158212ec0a55c1e7255562d4813ad3316592b1f74df041d3c06"
         },
         "32bit": {
-            "url": "https://github.com/neovim/neovim/releases/download/v0.4.4/nvim-win32.zip",
-            "hash": "2b8011cbe4a4028d8fddfecf555b5a66d05ad34d36e242ff26b418ddf33b323f"
+            "url": "https://github.com/neovim/neovim/releases/download/v0.5.0/nvim-win32.zip",
+            "hash": "9d0dcdc535ace7500e8395e2d814a415fb9405aedb5cb56382b9f96f98c272e9"
         }
     },
     "extract_dir": "Neovim",

--- a/bucket/neovim.json
+++ b/bucket/neovim.json
@@ -1,0 +1,41 @@
+{
+    "version": "0.4.4",
+    "description": "Vim-fork focused on extensibility and usability",
+    "homepage": "https://neovim.io/",
+    "license": {
+        "identifier": "Apache-2.0,Vim",
+        "url": "https://github.com/neovim/neovim/blob/master/LICENSE"
+    },
+    "suggest": {
+        "vcredist": "extras/vcredist2015"
+    },
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/neovim/neovim/releases/download/v0.4.4/nvim-win64.zip",
+            "hash": "4b88daae8427624f82abb10eb6e527f4b0c600e83aaa9a0857d06106b445bbd3"
+        },
+        "32bit": {
+            "url": "https://github.com/neovim/neovim/releases/download/v0.4.4/nvim-win32.zip",
+            "hash": "2b8011cbe4a4028d8fddfecf555b5a66d05ad34d36e242ff26b418ddf33b323f"
+        }
+    },
+    "extract_dir": "Neovim",
+    "bin": "bin\\nvim.exe",
+    "post_install": [
+        "Remove-Item $dir\\share\\nvim-qt, $dir\\bin\\bearer, $dir\\bin\\iconengines, $dir\\bin\\imageformats, $dir\\bin\\platforms, $dir\\bin\\styles, $dir\\bin\\translations -Recurse -ErrorAction Ignore",
+        "Remove-Item $dir\\bin\\D3Dcompiler_47.dll, $dir\\bin\\libEGL.dll, $dir\\bin\\libgcc_s_dw2-1.dll, $dir\\bin\\libGLESV2.dll, $dir\\bin\\libstdc++-6.dll, $dir\\bin\\libwinpthread-1.dll, $dir\\bin\\nvim-qt.exe, $dir\\bin\\opengl32sw.dll, $dir\\bin\\Qt* -ErrorAction Ignore"
+    ],
+    "checkver": {
+        "github": "https://github.com/neovim/neovim"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/neovim/neovim/releases/download/v$version/nvim-win64.zip"
+            },
+            "32bit": {
+                "url": "https://github.com/neovim/neovim/releases/download/v$version/nvim-win32.zip"
+            }
+        }
+    }
+}


### PR DESCRIPTION
So this is a bit of a tricky one: Neovim ships Windows binaries with a GUI client, which IMO they shouldn't because it's a console application after all. I understand they are possibly trying to mimic Vim which ships with gVim as the GUI client, but terminal emulators today are more than capable of handling both Vim and Neovim themselves. I tried to ask Neovim devs to allow disabling the bundling of the client here neovim/neovim#14552, but nothing happened. 

So, as with other popular GUI clients, like [FVim](https://github.com/yatli/fvim) or [Neovide](https://github.com/Kethku/neovide), I have decoupled [Neovim Qt](https://github.com/equalsraf/neovim-qt) with its terminal counterpart.