### PR TITLE
justcolorpicker@5.5: Fix URL and hash

### DIFF
--- a/bucket/justcolorpicker.json
+++ b/bucket/justcolorpicker.json
@@ -5,14 +5,15 @@
     "license": "Freeware",
     "architecture": {
         "64bit": {
-            "url": "https://annystudio.com/software/colorpicker/jcpicker.exe",
-            "hash": "f24ded6b41d211f1cbfc5c85783b82c87217c5d845a259ad9785bdd7db07ca4e"
+            "url": "https://annystudio.com/jcpicker.exe",
+            "hash": "530047d43a009458d56f326b1e2d53cde19b79fe4c49def0f98ddd8e90190b34"
         },
         "32bit": {
-            "url": "https://annystudio.com/software/colorpicker/jcpicker_32bit.exe#/jcpicker.exe",
-            "hash": "16851de9a73001a8f00c00a9357a67cadb282ee73fba24f3629b89d3a8648557"
+            "url": "https://annystudio.com/jcpicker_32bit.exe#/jcpicker.exe",
+            "hash": "0762c6718020b804a5e7286bdc9a53fc772eb3a5f17e2d1ede2584a964bf8242"
         }
     },
+    "bin": "jcpicker.exe",
     "shortcuts": [
         [
             "jcpicker.exe",
@@ -25,10 +26,10 @@
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://annystudio.com/software/colorpicker/jcpicker.exe"
+                "url": "https://annystudio.com/jcpicker.exe"
             },
             "32bit": {
-                "url": "https://annystudio.com/software/colorpicker/jcpicker_32bit.exe#/jcpicker.exe"
+                "url": "https://annystudio.com/jcpicker_32bit.exe#/jcpicker.exe"
             }
         }
     }


### PR DESCRIPTION
`scoop install justcolorpicker` was giving this error:

![image](https://user-images.githubusercontent.com/46838874/134123160-298a1819-7c44-4050-a62d-537293c04907.png)

I fixed it :)

Also added shim.