### PR TITLE
neovim-qt@0.2.16.1: Fix architecture

### DIFF
--- a/bucket/neovim-qt.json
+++ b/bucket/neovim-qt.json
@@ -6,12 +6,8 @@
   "suggest": {
     "neovim": "neovim"
   },
-  "architecture": {
-    "64bit": {
-      "url": "https://github.com/equalsraf/neovim-qt/releases/download/v0.2.16.1/neovim-qt.zip",
-      "hash": "ddb4492db03da407703fb0ab271c4eb060250d1a7d71200e2b3b981cb0de59de"
-    }
-  },
+  "url": "https://github.com/equalsraf/neovim-qt/releases/download/v0.2.16.1/neovim-qt.zip",
+  "hash": "ddb4492db03da407703fb0ab271c4eb060250d1a7d71200e2b3b981cb0de59de",
   "bin": "bin\\nvim-qt.exe",
   "shortcuts": [
     [
@@ -19,14 +15,8 @@
       "Neovim Qt"
     ]
   ],
-  "checkver": {
-    "github": "https://github.com/equalsraf/neovim-qt"
-  },
+  "checkver": "github",
   "autoupdate": {
-    "architecture": {
-      "64bit": {
-        "url": "https://github.com/equalsraf/neovim-qt/releases/download/v$version/neovim-qt.zip"
-      }
-    }
+    "url": "https://github.com/equalsraf/neovim-qt/releases/download/v$version/neovim-qt.zip"
   }
 }


### PR DESCRIPTION
The architecture of the binary was wrong. I fixed it. Now it should work on both 32bit and 64bit.