### PR TITLE
winsetview: update hash

### DIFF
--- a/bucket/winsetview.json
+++ b/bucket/winsetview.json
@@ -3,7 +3,7 @@
     "description": "WinSetView is a tool that will let you easily set File Explorer default folder views.",
     "homepage": "https://github.com/LesFerch/WinSetView",
     "url": "https://github.com/LesFerch/WinSetView/archive/refs/tags/2.80.zip",
-    "hash": "b1897f0ea05153d3e363eb909a15605c25a9c6c0dbee523e7053e406e5545e93",
+    "hash": "a9a13760039cd62f0d4712af5b33088f18ef81438d8705aa6258bc72cb6cb6f4",
     "extract_dir": "WinSetView-2.80",
     "bin":[
         "WinSetView.ps1"


### PR DESCRIPTION
```
Installing 'winsetview' (2.80) [64bit] from naderi bucket
2.80.zip (1,1 MB) [===============================================================================================================================================================] 100%
Checking hash of 2.80.zip ... ERROR Hash check failed!
App:         naderi/winsetview
URL:         https://github.com/LesFerch/WinSetView/archive/refs/tags/2.80.zip
First bytes: 50 4B 03 04 0A 00 00 00
Expected:    b1897f0ea05153d3e363eb909a15605c25a9c6c0dbee523e7053e406e5545e93
Actual:      a9a13760039cd62f0d4712af5b33088f18ef81438d8705aa6258bc72cb6cb6f4

Please try again or create a new issue by using the following link and paste your console output:
https://github.com/naderi/scoop-bucket/issues/new?title=winsetview%402.80%3a+hash+check+failed
```